### PR TITLE
Favor recently-seen nodes to connect to, and try more often

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -61,6 +61,13 @@ double CAddrInfo::GetChance(int64_t nNow) const
     if (nSinceLastTry < 0)
         nSinceLastTry = 0;
 
+    // similar to Bitcoin prior to March 2015
+    fChance *= 36000.0 / (36000.0 + nSinceLastSeen);
+
+    // additional penalty not seen in Bitcoin
+    if (nSinceLastSeen > 864000)
+        fChance *= 0.03;
+
     // deprioritize very recent attempts away
     if (nSinceLastTry < 60 * 10)
         fChance *= 0.01;
@@ -336,7 +343,7 @@ CAddrInfo CAddrMan::Select_(bool newOnly)
 
     // Track number of attempts to find a table entry, before giving up to avoid infinite loop
     const int kMaxRetries = 200000;         // magic number so unit tests can pass
-    const int kRetriesBetweenSleep = 1000;
+    const int kRetriesBetweenSleep = 10000;
     const int kRetrySleepInterval = 100;    // milliseconds
 
     if (newOnly && nNew == 0)


### PR DESCRIPTION
First, this reverts a Bitcoin commit from 2015:

```diff
commit f68ba3f67bd500a64fb8932c6b41924ddc31d76f
Author: Pieter Wuille <pieter.wuille@gmail.com>
Date:   Thu Mar 19 09:44:26 2015 -0700

    Do not bias outgoing connections towards fresh addresses
    
    This change was suggested as Countermeasure 2 in
    Eclipse Attacks on Bitcoin's Peer-to-Peer Network, Ethan Heilman,
    Alison Kendler, Aviv Zohar, Sharon Goldberg. ePrint Archive Report
    2015/263. March 2015.

diff --git a/src/addrman.cpp b/src/addrman.cpp
index 05688fb..eb431ec 100644
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -63,8 +63,6 @@ double CAddrInfo::GetChance(int64_t nNow) const
     if (nSinceLastTry < 0)
         nSinceLastTry = 0;
 
-    fChance *= 600.0 / (600.0 + nSinceLastSeen);
-
     // deprioritize very recent attempts away
     if (nSinceLastTry < 60 * 10)
         fChance *= 0.01;
```

Then, it changes the constant in the restored line from 10 minutes to 10 hours (reducing the penalty for nodes that are not seen for only a few hours), and it adds an additional penalty for nodes not seen in 10 days (the `ADDRMAN_*` constants are such that information about a node is kept for up to 30 days, and this is unchanged for now).

Finally, it also makes `Select()` sleep less before returning an address. (In testing, it would actually loop for tens of thousands of times in there, so the increase in sleep threshold from 1000 to 10000 does reduce the sleep time per call.)

The cumulative effect of these changes is that a new node initially lacking `peers.dat` gets to the maximum of 8 connections in ~10 minutes, which is better than what we're seeing without these changes on our network now.