### PR TITLE
Assume non-Groth16 Sprout proofs are invalid

### DIFF
--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -92,9 +92,8 @@ public:
 
     bool operator()(const libzcash::PHGRProof& proof) const
     {
-        // We checkpoint after Sapling activation, so we can skip verification
-        // for all Sprout proofs.
-        return true;
+        // We had Sapling since block 1, so we can disallow Sprout proofs.
+        return false;
     }
 
     bool operator()(const libzcash::GrothProof& proof) const


### PR DESCRIPTION
This is the more obvious one of two (or more) changes (to be) discussed with Zcash folks at https://github.com/zcash/zcash/issues/3831